### PR TITLE
Fix: Performance issue when menu item has many child blocks.

### DIFF
--- a/src/menu-item/edit.js
+++ b/src/menu-item/edit.js
@@ -198,7 +198,6 @@ export default compose([
 	withSelect((select, ownProps) => {
 		const {
 			hasSelectedInnerBlock,
-			getClientIdsOfDescendants,
 			getBlockCount,
 			getBlockParentsByBlockName,
 			getBlock

--- a/src/menu-item/edit.js
+++ b/src/menu-item/edit.js
@@ -199,13 +199,13 @@ export default compose([
 		const {
 			hasSelectedInnerBlock,
 			getClientIdsOfDescendants,
+			getBlockCount,
 			getBlockParentsByBlockName,
 			getBlock
 		} = select('core/block-editor');
 		const { clientId } = ownProps;
 		const isParentOfSelectedBlock = hasSelectedInnerBlock(clientId, true);
-		const hasDescendants = !!getClientIdsOfDescendants([clientId])
-			.length;
+		const hasDescendants = !!getBlockCount(clientId);
 		const rootBlockClientId = head(
 			getBlockParentsByBlockName( clientId, 'getwid-megamenu/menu' )
 		);


### PR DESCRIPTION
The calls to `getClientIdsOfDescendants` are causing performance issues when there are multiple menu items with many child blocks.  It degrades to the point where Gutenberg is completely unusable due to the browser freezing up - even with incognito and no extensions that could be interfering.

The core navigation block had similar issues: https://github.com/WordPress/gutenberg/pull/40700/files