### PR TITLE
PHP8: Check `id` attribute exists

### DIFF
--- a/includes/blocks/MegaMenuItem.php
+++ b/includes/blocks/MegaMenuItem.php
@@ -48,7 +48,7 @@ class MegaMenuItem extends AbstractBlock {
 		);
 
 		$item_link_style = $font_style['inline_styles'] . $text_style['inline_styles'];
-		$is_active = $attributes['kind'] == 'post-type' && $attributes['id'] === get_the_ID();
+		$is_active = $attributes['kind'] == 'post-type' && isset($attributes['id']) ? $attributes['id'] : null === get_the_ID();
 
 		$item_classes = array_merge(
 			[ 'wp-block-getwid-megamenu-item' ],


### PR DESCRIPTION
Check `id` attribute exists on `MegaMenuItem` before accessing in `$is_active` check. Menu items that are custom URLs (not page / post links) do not have an `id`. PHP 8 now throws `E_WARNING` not `E_NOTICE` as PHP 7 did on invalid array index access.

Fixes #11