### PR TITLE
Fix: Compatibility with WordPress 6.4.1 vulnerabilities.

### DIFF
--- a/includes/BlockRegister.php
+++ b/includes/BlockRegister.php
@@ -22,7 +22,8 @@ class BlockRegister {
 				'wp-element',
 				'wp-blocks',
 				'wp-components',
-				'wp-polyfill'
+				'wp-polyfill',
+				'lodash',
 			],
 			GETWID_MEGAMENU_VERSION,
 			true


### PR DESCRIPTION
Fix: Compatibility with WordPress 6.4.1 vulnerabilities.

Console error: lodash is not defined in WordPress 6.4.1.

https://prnt.sc/jfTX-IWJu2qK
