### PR TITLE
Add support for FontAwesome icons

### DIFF
--- a/includes/blocks/MegaMenuItem.php
+++ b/includes/blocks/MegaMenuItem.php
@@ -22,6 +22,10 @@ class MegaMenuItem extends AbstractBlock {
 			array(
 				'code'   => array(),
 				'em'     => array(),
+				'i'      => array(
+					'style' => array(),
+					'class' => array(),
+				),
 				'img'    => array(
 					'scale' => array(),
 					'class' => array(),

--- a/includes/blocks/PlainMenuItem.php
+++ b/includes/blocks/PlainMenuItem.php
@@ -22,6 +22,10 @@ class PlainMenuItem extends AbstractBlock {
 			array(
 				'code'   => array(),
 				'em'     => array(),
+				'i'      => array(
+					'style' => array(),
+					'class' => array(),
+				),
 				'img'    => array(
 					'scale' => array(),
 					'class' => array(),


### PR DESCRIPTION
This PR adds the `<i>` element used by FontAwesome (and other icon packs) to the list of HTML elements allowed in `wp_kses`. This enables adding icons to menu items either manually or through plugins such as JVM Gutenberg Rich Text Icons.